### PR TITLE
Add internet monitoring tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+pingtest.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # PingTest
+
+Simple tools for monitoring internet speed and ping. Run `monitor.py` to collect data into `pingtest.db` and `web.py` to view graphs.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Collect data for an hour (tests every minute):
+   ```bash
+   python monitor.py 3600 --interval 60
+   ```
+3. Start web server and open `http://localhost:8000` in browser:
+   ```bash
+   python web.py
+   ```

--- a/monitor.py
+++ b/monitor.py
@@ -1,0 +1,76 @@
+import argparse
+import sqlite3
+import time
+from pythonping import ping
+import speedtest
+
+DB_PATH = 'pingtest.db'
+SERVER_ID = 64665  # Oldenburg, Germany
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts REAL,
+            ping_ms REAL,
+            download_mbps REAL,
+            upload_mbps REAL,
+            router_ping_ms REAL,
+            jitter_ms REAL
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def measure(server_id=SERVER_ID, router_ip='192.168.1.1'):
+    st = speedtest.Speedtest()
+    st.get_servers([server_id])
+    st.get_best_server()
+    st.download()
+    st.upload()
+    results = st.results.dict()
+    ping_ms = results['ping']
+    download_mbps = results['download'] / 1e6
+    upload_mbps = results['upload'] / 1e6
+
+    resp = ping(router_ip, count=5, timeout=2)
+    router_ping_ms = resp.rtt_avg_ms
+    jitter_ms = resp.rtt_max_ms - resp.rtt_min_ms
+
+    return ping_ms, download_mbps, upload_mbps, router_ping_ms, jitter_ms
+
+
+def monitor(duration_sec, interval_sec=60):
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    start = time.time()
+    while time.time() - start < duration_sec:
+        ts = time.time()
+        try:
+            ping_ms, dl, ul, router_ping, jitter = measure()
+        except Exception as e:
+            print('measurement error:', e)
+            ping_ms = dl = ul = router_ping = jitter = None
+        cur.execute(
+            'INSERT INTO results (ts, ping_ms, download_mbps, upload_mbps, router_ping_ms, jitter_ms) VALUES (?, ?, ?, ?, ?, ?)',
+            (ts, ping_ms, dl, ul, router_ping, jitter),
+        )
+        conn.commit()
+        remaining = start + duration_sec - time.time()
+        if remaining <= 0:
+            break
+        time.sleep(min(interval_sec, remaining))
+    conn.close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Monitor network quality')
+    parser.add_argument('duration', type=int, help='monitoring duration in seconds')
+    parser.add_argument('--interval', type=int, default=60, help='interval between tests in seconds')
+    args = parser.parse_args()
+    monitor(args.duration, args.interval)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+speedtest-cli
+pythonping
+flask

--- a/web.py
+++ b/web.py
@@ -1,0 +1,83 @@
+from flask import Flask, jsonify, render_template_string
+import sqlite3
+
+DB_PATH = 'pingtest.db'
+
+app = Flask(__name__)
+
+
+def query_results():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute('SELECT ts, ping_ms, download_mbps, upload_mbps, router_ping_ms, jitter_ms FROM results ORDER BY ts')
+    rows = cur.fetchall()
+    conn.close()
+    return [dict(row) for row in rows]
+
+
+@app.route('/data')
+def data():
+    return jsonify(query_results())
+
+
+HTML = """
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Network Stats</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <canvas id="speedChart" width="800" height="400"></canvas>
+    <canvas id="pingChart" width="800" height="400"></canvas>
+    <script>
+    async function draw() {
+        const resp = await fetch('/data');
+        const data = await resp.json();
+        const labels = data.map(r => new Date(r.ts * 1000));
+        const dl = data.map(r => r.download_mbps);
+        const ul = data.map(r => r.upload_mbps);
+        const ping = data.map(r => r.ping_ms);
+        const router = data.map(r => r.router_ping_ms);
+        const jitter = data.map(r => r.jitter_ms);
+
+        new Chart(document.getElementById('speedChart').getContext('2d'), {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {label: 'Download Mbps', data: dl, borderColor: 'blue', fill: false},
+                    {label: 'Upload Mbps', data: ul, borderColor: 'green', fill: false}
+                ]
+            },
+            options: {scales: {x: {type: 'time', time: {unit: 'minute'}}}}
+        });
+
+        new Chart(document.getElementById('pingChart').getContext('2d'), {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {label: 'Ping ms', data: ping, borderColor: 'red', fill: false},
+                    {label: 'Router Ping ms', data: router, borderColor: 'orange', fill: false},
+                    {label: 'Jitter ms', data: jitter, borderColor: 'purple', fill: false}
+                ]
+            },
+            options: {scales: {x: {type: 'time', time: {unit: 'minute'}}}}
+        });
+    }
+    draw();
+    </script>
+</body>
+</html>
+"""
+
+
+@app.route('/')
+def index():
+    return render_template_string(HTML)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- add Python script `monitor.py` for collecting ping and speed test data into SQLite
- provide a simple Flask `web.py` viewer that plots the metrics with Chart.js
- document usage in README
- include dependency list and `.gitignore`

## Testing
- `python3 -m py_compile monitor.py web.py`


------
https://chatgpt.com/codex/tasks/task_e_6884508a415483328b723d109b5463d6